### PR TITLE
[#25] Jwt 필터 제작 및 Redis 도입

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -67,6 +67,19 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
         run: aws s3 cp likelion.tar s3://${{ secrets.S3_BUCKET_NAME }}/likelion.tar
 
+      - name: Pull Redis Docker image
+        run: docker pull redis
+
+      - name: Save Docker image as tar
+        run: docker save redis -o redis.tar
+
+      - name: Upload to S3
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+        run: aws s3 cp redis.tar s3://${{ secrets.S3_BUCKET_NAME }}/redis.tar
+
   deploy:
     runs-on: ubuntu-latest
     needs: delivery
@@ -78,6 +91,11 @@ jobs:
           username: ec2-user
           key: ${{ secrets.AWS_PRIVATE_KEY }}
           script: |
+            aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/redis.tar redis.tar
+            sudo docker load -i redis.tar
+            sudo docker stop $(sudo docker ps -a -q) || true
+            sudo docker rm $(sudo docker ps -a -q) || true
+            sudo docker run -d --log-driver=syslog -p 6379:6379 redis --requirepass "omeb4417"
             aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/likelion.tar likelion.tar
             sudo docker load -i likelion.tar
             sudo docker stop $(sudo docker ps -a -q) || true

--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Save Docker image as tar
         run: docker save redis -o redis.tar
 
+      - name : add permision to redis.tar
+        run : sudo chmod 777 redis.tar
+
       - name: Upload to S3
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
@@ -95,10 +98,10 @@ jobs:
             sudo docker load -i redis.tar
             sudo docker stop $(sudo docker ps -a -q) || true
             sudo docker rm $(sudo docker ps -a -q) || true
-            sudo docker run -d --log-driver=syslog -p 6379:6379 redis --requirepass "omeb4417"
+            sudo docker run -d --log-driver=syslog --name redis --net mybridge -p 6379:6379 redis --requirepass "omeb4417"
             aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/likelion.tar likelion.tar
             sudo docker load -i likelion.tar
             sudo docker stop $(sudo docker ps -a -q) || true
             sudo docker rm $(sudo docker ps -a -q) || true
-            sudo docker run -d --log-driver=syslog -p 8080:8080 likelion
+            sudo docker run -d --log-driver=syslog --net mybridge -p 8080:8080 likelion
             sudo docker image prune -a -f

--- a/src/main/java/com/example/OMEB/domain/profile/application/ProfileUrlUtill.java
+++ b/src/main/java/com/example/OMEB/domain/profile/application/ProfileUrlUtill.java
@@ -3,6 +3,7 @@ package com.example.OMEB.domain.profile.application;
 import com.example.OMEB.global.base.exception.ErrorCode;
 import com.example.OMEB.global.base.exception.ServiceException;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -10,12 +11,13 @@ import java.util.Map;
 import java.util.UUID;
 
 @Component
+@PropertySource("classpath:/security/application-s3.yml")
 public class ProfileUrlUtill {
-    @Value("${profile.s3.deafult.url}")
+    @Value("${cloud.profile.s3.default.url}")
     private static String defaultUrl;
     @Value("${cloud.s3.bucket}")
     private static String bucket;
-    public static String  getDefaultUrl() {
+    public static String getDefaultUrl() {
         return defaultUrl;
     }
 

--- a/src/main/java/com/example/OMEB/domain/user/persistence/entity/User.java
+++ b/src/main/java/com/example/OMEB/domain/user/persistence/entity/User.java
@@ -75,5 +75,6 @@ public class User extends BaseEntity {
     public User(OAuth2Provider provider, String providerId) {
         this.provider = provider;
         this.providerId = providerId;
+        this.profileImageUrl = ProfileUrlUtill.getDefaultUrl();
     }
 }

--- a/src/main/java/com/example/OMEB/global/base/exception/ErrorCode.java
+++ b/src/main/java/com/example/OMEB/global/base/exception/ErrorCode.java
@@ -17,8 +17,11 @@ public enum ErrorCode {
     INVALID_JSON(HttpStatus.BAD_REQUEST, "COMMON_0007", "JSON 파싱 오류입니다."),
     INVALID_INPUT_TAG(HttpStatus.BAD_REQUEST, "COMMON_0008", "감정 태그 입력이 잘못되었습니다."),
 
-    // OAuth
-    NOT_FOUND_COOKIE(HttpStatus.NOT_FOUND, "OAUTH_0001", "쿠키를 찾을 수 없습니다"),
+    // Auth
+    NOT_FOUND_COOKIE(HttpStatus.NOT_FOUND, "AUTH_0001", "쿠키를 찾을 수 없습니다."),
+    JWT_EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "AUTH_0002", "만료된 Jwt 토큰입니다."),
+    JWT_AUTHENTICATION_FAILED(HttpStatus.BAD_REQUEST, "AUTH_0003", "Jwt 토큰 인증이 실패했습니다."),
+    JWT_NOT_EXIST(HttpStatus.BAD_REQUEST, "AUTH_0004", "Jwt 토큰이 존재하지 않습니다."),
 
     // User
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER_0001", "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/example/OMEB/global/base/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/OMEB/global/base/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.example.OMEB.global.base.exception;
 
-import com.example.OMEB.global.base.dto.FailedResponseBody;
 import com.example.OMEB.global.base.dto.ResponseBody;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
@@ -25,5 +24,11 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.badRequest()
                 .body(createFailureResponse(ErrorCode.INVALID_INPUT_VALUE, errorMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseBody<Void>> handleException(HttpServletRequest request, Exception e) {
+        return ResponseEntity.internalServerError()
+                .body(createFailureResponse(ErrorCode.INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/example/OMEB/global/config/JwtConfig.java
+++ b/src/main/java/com/example/OMEB/global/config/JwtConfig.java
@@ -1,0 +1,18 @@
+package com.example.OMEB.global.config;
+
+import com.example.OMEB.global.jwt.JwtUtils;
+import com.example.OMEB.global.jwt.refreshToken.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtConfig {
+    private final RefreshTokenRepository refreshTokenRepository;
+    @Bean
+    public JwtUtils jwtUtils(@Value("${jwt.secret-key}") String stringSecretKey){
+        return new JwtUtils(stringSecretKey, refreshTokenRepository);
+    }
+}

--- a/src/main/java/com/example/OMEB/global/config/RedisConfig.java
+++ b/src/main/java/com/example/OMEB/global/config/RedisConfig.java
@@ -1,0 +1,41 @@
+package com.example.OMEB.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@PropertySource("classpath:/security/application-db.yml")
+public class RedisConfig {
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+        configuration.setPassword(password);
+        return new LettuceConnectionFactory(configuration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(){
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+
+}

--- a/src/main/java/com/example/OMEB/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/OMEB/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.example.OMEB.global.config;
 
+import com.example.OMEB.global.jwt.JwtFilter;
+import com.example.OMEB.global.jwt.JwtUtils;
 import com.example.OMEB.global.oauth.HttpCookiesOAuth2AuthorizationRequestRepository;
 import com.example.OMEB.global.oauth.handler.OAuth2AuthenticationFailureHandler;
 import com.example.OMEB.global.oauth.handler.OAuth2AuthenticationSuccessHandler;
@@ -13,6 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @EnableWebSecurity
 @Configuration
@@ -22,6 +25,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oauth2AuthenticationSuccessHandler;
     private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+    private final JwtUtils jwtUtils;
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -36,6 +40,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests((requests) -> requests
 //                        .requestMatchers().permitAll()
                         .anyRequest().permitAll())
+
+                .addFilterBefore(new JwtFilter(jwtUtils), UsernamePasswordAuthenticationFilter.class)
 
                 .oauth2Login((configure) -> configure
                         .authorizationEndpoint((config) -> config.authorizationRequestRepository(httpCookiesOAuth2AuthorizationRequestRepository))

--- a/src/main/java/com/example/OMEB/global/jwt/CustomUserPrincipal.java
+++ b/src/main/java/com/example/OMEB/global/jwt/CustomUserPrincipal.java
@@ -1,0 +1,4 @@
+package com.example.OMEB.global.jwt;
+
+public record CustomUserPrincipal(Long userId) {
+}

--- a/src/main/java/com/example/OMEB/global/jwt/JwtFilter.java
+++ b/src/main/java/com/example/OMEB/global/jwt/JwtFilter.java
@@ -1,0 +1,55 @@
+package com.example.OMEB.global.jwt;
+
+import com.example.OMEB.global.base.dto.FailedResponseBody;
+import com.example.OMEB.global.base.exception.ErrorCode;
+import com.example.OMEB.global.jwt.exception.CustomJwtException;
+import com.example.OMEB.global.jwt.exception.JwtNotExistException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.example.OMEB.global.utils.CookieUtils.objectMapper;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private final String HTTP_AUTHORIZATION_HEADER = "Authorization";
+    private final String TOKEN_TYPE = "Bearer ";
+    private final JwtUtils jwtUtils;
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try{
+            String jwtToken = resolveToken(request).orElseThrow(() ->
+                    new JwtNotExistException(ErrorCode.JWT_NOT_EXIST));
+            if (jwtUtils.validateToken(jwtToken)){
+                Authentication authentication = jwtUtils.getAuthentication(jwtToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            filterChain.doFilter(request, response);
+        } catch (CustomJwtException e){
+            response.setStatus(e.getErrorCode().getStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE+ ";charset=UTF-8");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    FailedResponseBody.createFailureResponse(e.getErrorCode())));
+        }
+    }
+
+    public Optional<String> resolveToken(HttpServletRequest request){
+        // jwt 토큰 파싱
+        String bearerToken = request.getHeader(HTTP_AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(TOKEN_TYPE))
+            return Optional.of(bearerToken.substring(7));
+
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/JwtUtils.java
+++ b/src/main/java/com/example/OMEB/global/jwt/JwtUtils.java
@@ -1,17 +1,23 @@
 package com.example.OMEB.global.jwt;
 
 
-import io.jsonwebtoken.Jwts;
+import com.example.OMEB.global.base.exception.ErrorCode;
+import com.example.OMEB.global.jwt.exception.JwtExpiredException;
+import com.example.OMEB.global.jwt.exception.JwtVerifyException;
+import com.example.OMEB.global.jwt.refreshToken.RefreshToken;
+import com.example.OMEB.global.jwt.refreshToken.RefreshTokenRepository;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.crypto.SecretKey;
-import java.util.Base64;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Component
 @PropertySource("classpath:/security/application-security.yml")
@@ -21,8 +27,10 @@ public class JwtUtils {
     private String accessTokenExpirationTime;
     @Value("${jwt.refresh-token-expiration-time}")
     private String refreshTokenExpirationTime;
+    private final RefreshTokenRepository refreshTokenRepository;
 
-    public JwtUtils(@Value("${jwt.secret-key}") String stringSecretKey){
+    public JwtUtils(@Value("${jwt.secret-key}") String stringSecretKey, RefreshTokenRepository refreshTokenRepository){
+        this.refreshTokenRepository = refreshTokenRepository;
         String keyBase64Encoded = Base64.getEncoder().encodeToString(stringSecretKey.getBytes());
         secretKey = Keys.hmacShaKeyFor(keyBase64Encoded.getBytes());
     }
@@ -51,6 +59,27 @@ public class JwtUtils {
                 .compact();
 
         // TODO : refresh 토큰 저장
+        refreshTokenRepository.save(new RefreshToken(userId, refreshToken));
+
         return refreshToken;
+    }
+    public boolean validateToken(String jwtToken){
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(jwtToken);
+            return true;
+        } catch (ExpiredJwtException e) {
+            throw new JwtExpiredException(ErrorCode.JWT_EXPIRED_TOKEN);
+        } catch (Exception e) {
+            throw new JwtVerifyException(ErrorCode.JWT_AUTHENTICATION_FAILED);
+        }
+    }
+
+    public Authentication getAuthentication(String jwtToken){
+        Claims claims = Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(jwtToken).getPayload();
+
+        List<? extends SimpleGrantedAuthority> authorities = new ArrayList<>();
+        CustomUserPrincipal principal = new CustomUserPrincipal(claims.get("USER_ID", Long.class));
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 }

--- a/src/main/java/com/example/OMEB/global/jwt/exception/CustomJwtException.java
+++ b/src/main/java/com/example/OMEB/global/jwt/exception/CustomJwtException.java
@@ -1,0 +1,14 @@
+package com.example.OMEB.global.jwt.exception;
+
+import com.example.OMEB.global.base.exception.ErrorCode;
+import io.jsonwebtoken.JwtException;
+import lombok.Getter;
+
+@Getter
+public class CustomJwtException extends JwtException {
+    private final ErrorCode errorCode;
+    public CustomJwtException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/exception/JwtExpiredException.java
+++ b/src/main/java/com/example/OMEB/global/jwt/exception/JwtExpiredException.java
@@ -1,0 +1,9 @@
+package com.example.OMEB.global.jwt.exception;
+
+import com.example.OMEB.global.base.exception.ErrorCode;
+
+public class JwtExpiredException extends CustomJwtException {
+    public JwtExpiredException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/exception/JwtNotExistException.java
+++ b/src/main/java/com/example/OMEB/global/jwt/exception/JwtNotExistException.java
@@ -1,0 +1,9 @@
+package com.example.OMEB.global.jwt.exception;
+
+import com.example.OMEB.global.base.exception.ErrorCode;
+
+public class JwtNotExistException extends CustomJwtException{
+    public JwtNotExistException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/exception/JwtVerifyException.java
+++ b/src/main/java/com/example/OMEB/global/jwt/exception/JwtVerifyException.java
@@ -1,0 +1,10 @@
+package com.example.OMEB.global.jwt.exception;
+
+import com.example.OMEB.global.base.exception.ErrorCode;
+
+
+public class JwtVerifyException extends CustomJwtException {
+    public JwtVerifyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/refreshToken/RefreshToken.java
+++ b/src/main/java/com/example/OMEB/global/jwt/refreshToken/RefreshToken.java
@@ -1,0 +1,19 @@
+package com.example.OMEB.global.jwt.refreshToken;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@RedisHash(value = "refreshToken", timeToLive = 1209600)
+@AllArgsConstructor
+@Getter
+public class RefreshToken {
+    @Id
+    private Long userId;
+    private String refreshToken;
+
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/example/OMEB/global/jwt/refreshToken/RefreshTokenRepository.java
+++ b/src/main/java/com/example/OMEB/global/jwt/refreshToken/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.example.OMEB.global.jwt.refreshToken;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/example/OMEB/global/oauth/HttpCookiesOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/example/OMEB/global/oauth/HttpCookiesOAuth2AuthorizationRequestRepository.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
-import org.springframework.util.Assert;
 
 @Component
 public class HttpCookiesOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
@@ -17,14 +16,11 @@ public class HttpCookiesOAuth2AuthorizationRequestRepository implements Authoriz
     public final int COOKIE_EXPIRE_SECONDS = 180;
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        Assert.notNull(request, "request cannot be null");
         return getAuthorizationRequest(request);
     }
 
     @Override
     public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
-        Assert.notNull(request, "request cannot be null");
-        Assert.notNull(response, "response cannot be null");
         if (authorizationRequest == null) {
             this.removeAuthorizationRequest(request, response);
         } else {
@@ -41,7 +37,6 @@ public class HttpCookiesOAuth2AuthorizationRequestRepository implements Authoriz
 
     @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
-        Assert.notNull(response, "response cannot be null");
         OAuth2AuthorizationRequest authorizationRequest = this.loadAuthorizationRequest(request);
 
         return authorizationRequest;

--- a/src/main/java/com/example/OMEB/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/example/OMEB/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,13 +1,17 @@
 package com.example.OMEB.global.oauth.handler;
 
+import com.example.OMEB.global.base.dto.FailedResponseBody;
+import com.example.OMEB.global.base.dto.ResponseBody;
 import com.example.OMEB.global.base.exception.ErrorCode;
 import com.example.OMEB.global.base.exception.ServiceException;
 import com.example.OMEB.global.oauth.HttpCookiesOAuth2AuthorizationRequestRepository;
 import com.example.OMEB.global.utils.CookieUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -16,11 +20,15 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.io.IOException;
 
 import static com.example.OMEB.global.oauth.HttpCookiesOAuth2AuthorizationRequestRepository.redirectUriCookieName;
+import static com.example.OMEB.global.utils.CookieUtils.objectMapper;
 
 @Component
-@RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     private final HttpCookiesOAuth2AuthorizationRequestRepository httpCookiesOAuth2AuthorizationRequestRepository;
+
+    public OAuth2AuthenticationFailureHandler(HttpCookiesOAuth2AuthorizationRequestRepository httpCookiesOAuth2AuthorizationRequestRepository) {
+        this.httpCookiesOAuth2AuthorizationRequestRepository = httpCookiesOAuth2AuthorizationRequestRepository;
+    }
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -28,15 +36,19 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         String targetUrl = CookieUtils.getCookie(request, redirectUriCookieName).getValue();
         if (targetUrl == null){
-            throw new ServiceException(ErrorCode.NOT_FOUND_COOKIE);
+            response.setStatus(ErrorCode.NOT_FOUND_COOKIE.getStatus().value());
+            response.setContentType(MediaType.APPLICATION_JSON_VALUE+ ";charset=UTF-8");
+            response.setCharacterEncoding("UTF-8");
+            response.getWriter().write(objectMapper.writeValueAsString(
+                    FailedResponseBody.createFailureResponse(ErrorCode.NOT_FOUND_COOKIE)));
+        } else{
+            targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                    .queryParam("error", exception.getLocalizedMessage())
+                    .build().toUriString();
+
+            httpCookiesOAuth2AuthorizationRequestRepository.removeCookies(request, response);
+
+            getRedirectStrategy().sendRedirect(request, response, targetUrl);
         }
-
-        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("error", exception.getLocalizedMessage())
-                .build().toUriString();
-
-        httpCookiesOAuth2AuthorizationRequestRepository.removeCookies(request, response);
-
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/example/OMEB/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/example/OMEB/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -2,8 +2,6 @@ package com.example.OMEB.global.oauth.handler;
 
 import com.example.OMEB.domain.user.persistence.entity.User;
 import com.example.OMEB.domain.user.persistence.repository.UserRepository;
-import com.example.OMEB.global.base.exception.ErrorCode;
-import com.example.OMEB.global.base.exception.ServiceException;
 import com.example.OMEB.global.jwt.JwtUtils;
 import com.example.OMEB.global.oauth.HttpCookiesOAuth2AuthorizationRequestRepository;
 import com.example.OMEB.global.oauth.user.OAuth2Provider;
@@ -46,18 +44,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             principal = null;
         }
 
-
         String providerId = principal.getUserInfo().getProviderId();
 
         isLogin = true;
         User user = userRepository.findByProviderId(providerId)
-                .orElseGet(() -> {
-                    return signUp(providerId, principal.getUserInfo().getProvider());
-                });
+                .orElseGet(() -> signUp(providerId, principal.getUserInfo().getProvider()));
 
         String accessToken = jwtUtils.createAccessToken(user.getId());
         String refreshToken = jwtUtils.createRefreshToken(user.getId());
-        // TODO : Redis에 refreshToken save
 
         Cookie redirectCookie = CookieUtils.getCookie(request, redirectUriCookieName);
         String redirectUri = UriComponentsBuilder.fromUriString(redirectCookie.getValue())
@@ -72,8 +66,9 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     }
     public User signUp(String providerId, OAuth2Provider provider){
         User user = new User(provider, providerId);
+        //TODO : 수정
+        user.updateProfileImageUrl("https://omeb-image.s3.ap-northeast-2.amazonaws.com/default_profile.png");
         isLogin = false;
         return userRepository.save(user);
-        // TODO : Redis repository
     }
 }

--- a/src/main/java/com/example/OMEB/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/OMEB/global/oauth/service/CustomOAuth2UserService.java
@@ -18,12 +18,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
        OAuth2User oAuth2User = super.loadUser(userRequest);
 
        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-       OAuth2UserInfo userinfo;
+       OAuth2UserInfo userinfo = null;
        switch (registrationId){
            case "google" -> userinfo = new GoogleUserInfo(oAuth2User.getAttributes());
            case "kakao" -> userinfo = new KakaoUserInfo(oAuth2User.getAttributes());
            case "naver" -> userinfo = new NaverUserInfo(oAuth2User.getAttributes());
-           default -> throw new IllegalArgumentException("지원하지 않는 로그인 공급자: " + registrationId);
        }
         return new OAuth2UserPrincipal(userinfo);
     }


### PR DESCRIPTION
### 🌱 작업 사항 
- Jwt 인증 필터 구현
- Redis 도입
- 수정사항 발견
### ❓ 리뷰 포인트
- 필터 로직
- ProfileUrlUtill 클래스부분에 @Value 필드는 static으로 선언하면 안된다고 합니다. 그래서 일단 OAuth 회원가입 할 때 프로필 사진 URI를 getDefaultUrl 사용하지 않고 만들어놓긴 했습니다.
- Redis를 배포 서버에 설치해야하는데, Redis docker 파일을 Spring docker 파일처럼 컨테이너 실행되도록 기존 CICD 파일 참고해서 만들어 봤습니다. 잘 굴러가지 않을 수도 있는데 추후 수정해보도록 하겠습니다.
- Redis 배포서버에 실행시키기 위해 인/아웃바운드 규칙에 6379 포트 뚫어놔야할 것 같습니다.
### 🦄 관련 이슈
resolves #25 
