### PR TITLE
책 제목 검색 api 구현

### DIFF
--- a/src/main/java/com/example/OMEB/domain/book/api/BookInfoControllerApi.java
+++ b/src/main/java/com/example/OMEB/domain/book/api/BookInfoControllerApi.java
@@ -4,6 +4,9 @@ import static com.example.OMEB.global.base.dto.SuccessResponseBody.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.example.OMEB.domain.book.presentation.dto.response.BookInfoResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookPageResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.EmotionBookTitleInfoListResponse;
 import com.example.OMEB.domain.review.persistence.vo.TagName;
@@ -18,6 +22,7 @@ import com.example.OMEB.global.aop.AssignUserId;
 import com.example.OMEB.global.aop.UserPrincipal;
 import com.example.OMEB.global.base.dto.ResponseBody;
 import com.example.OMEB.global.jwt.CustomUserPrincipal;
+import com.example.OMEB.global.utils.StringBlankUtils;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -52,4 +57,16 @@ public interface BookInfoControllerApi {
 		@ApiResponse(responseCode = "COMMON_0008", description = "감정 태그 입력이 잘못되었습니다.", content = @Content(mediaType = "application/json"))
 	})
 	ResponseEntity<ResponseBody<EmotionBookTitleInfoListResponse>> getEmotionRank(@RequestParam("emotion") @Schema(description = "감정", example = "ANGER") TagName emotion);
+
+	@Operation(summary = "책 검색 API", description = "책 제목을 검색하여 조회하는 API.")
+	@ApiResponses(value = {
+		@ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+			content = {
+				@Content(schema = @Schema(implementation = BookPageResponse.class), mediaType = "application/json")})
+	})
+	ResponseEntity<ResponseBody<BookPageResponse>> getBookSearch(@RequestParam("title") @Schema(description = "책 제목", example = "자바의 정석") String title,
+		@RequestParam(defaultValue = "1") @Schema(description = "조회할 페이지 넘버(가장 작은 수 1)", example = "1") int page,
+		@RequestParam(defaultValue = "10") @Schema(description = "한 페이지의 조회 될 책 수",example = "10") int size,
+		@RequestParam(defaultValue = "DESC") @Schema(description = "정렬 방법" , example = "DESC") String sortDirection,
+		@RequestParam(defaultValue = "createdAt") @Schema(description = "정렬 기준",example = "createdAt") String sortBy);
 }

--- a/src/main/java/com/example/OMEB/domain/book/application/service/BookQueryService.java
+++ b/src/main/java/com/example/OMEB/domain/book/application/service/BookQueryService.java
@@ -7,6 +7,7 @@ import com.example.OMEB.domain.book.persistence.repository.BookRepository;
 import com.example.OMEB.domain.book.persistence.repository.EmotionRankRepository;
 import com.example.OMEB.domain.book.presentation.dto.BookTitleInfo;
 import com.example.OMEB.domain.book.presentation.dto.response.BookInfoResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookPageResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.EmotionBookTitleInfoListResponse;
@@ -18,6 +19,7 @@ import com.example.OMEB.global.jwt.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -63,5 +65,9 @@ public class BookQueryService {
         List<BookTitleInfo> bookTitleInfos = byEmotion.getBookTitleInfos();
 
         return new EmotionBookTitleInfoListResponse(byEmotion.getEmotion(), bookTitleInfos);
+    }
+
+    public BookPageResponse findBookSearch(String title, Pageable pageable) {
+        return new BookPageResponse(bookRepository.findByTitleContaining(title, pageable));
     }
 }

--- a/src/main/java/com/example/OMEB/domain/book/application/usecase/BookUseCase.java
+++ b/src/main/java/com/example/OMEB/domain/book/application/usecase/BookUseCase.java
@@ -7,6 +7,8 @@ import com.example.OMEB.domain.book.application.service.NaverBookSearchClient;
 import com.example.OMEB.domain.book.presentation.dto.request.BookApplicationRequest;
 import com.example.OMEB.domain.book.presentation.dto.request.BookSearchRequest;
 import com.example.OMEB.domain.book.presentation.dto.response.BookInfoResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookPageResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.EmotionBookTitleInfoListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.NaverBookListResponse;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -78,4 +81,10 @@ public class BookUseCase {
         log.info("[BookUseCase] (getEmotionRank) get emotion rank request");
         return bookQueryService.findEmotionRank(emotion);
     }
+
+    @Transactional(readOnly = true)
+	public BookPageResponse getBookSearch(String title, Pageable pageable) {
+        log.info("[BookUseCase] (getBookSearch) get book search request");
+        return bookQueryService.findBookSearch(title, pageable);
+	}
 }

--- a/src/main/java/com/example/OMEB/domain/book/application/usecase/BookUseCase.java
+++ b/src/main/java/com/example/OMEB/domain/book/application/usecase/BookUseCase.java
@@ -17,6 +17,7 @@ import com.example.OMEB.domain.review.persistence.vo.TagName;
 import com.example.OMEB.global.base.exception.ErrorCode;
 import com.example.OMEB.global.base.exception.ServiceException;
 import com.example.OMEB.global.jwt.CustomUserPrincipal;
+import com.example.OMEB.global.utils.StringBlankUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,7 +41,7 @@ public class BookUseCase {
 
     //TODO : 검색 title 할 때 띄어쓰기 아예 없어야 검색 결과가 좋아짐!!
     public NaverBookListResponse searchTitleBooks(BookSearchRequest bookSearchRequest) {
-        List<NaverBookDTO> naverBookDTOS = naverBookSearchClient.searchBooks(bookSearchRequest.getTitle().replace(" ", ""), null);
+        List<NaverBookDTO> naverBookDTOS = naverBookSearchClient.searchBooks(StringBlankUtils.stringAllNotBlank(bookSearchRequest.getTitle()), null);
         if(naverBookDTOS.size() == 0) {
             throw new ServiceException(ErrorCode.APPLICATION_NOT_FOUND_BOOK);
         }else if(naverBookDTOS.size() >= 10) {

--- a/src/main/java/com/example/OMEB/domain/book/persistence/repository/BookRepository.java
+++ b/src/main/java/com/example/OMEB/domain/book/persistence/repository/BookRepository.java
@@ -1,11 +1,14 @@
 package com.example.OMEB.domain.book.persistence.repository;
 
 import com.example.OMEB.domain.book.persistence.entity.Book;
+import com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.awt.print.Pageable;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +18,10 @@ public interface BookRepository extends JpaRepository<Book,Long> {
 
     @Query(value = "SELECT b.* FROM book b LEFT JOIN review r ON r.book_id = b.id GROUP BY b.id ORDER BY COUNT(r.id) DESC LIMIT 10", nativeQuery = true)
     List<Book> findTopBooksByReviewRank();
+
+	// TODO : 걍 대충 구현함 나중에 수정해야함
+	@Query("SELECT new com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse(b.id, b.title, b.author, b.bookImage, b.price) "
+		+ "FROM Book b "
+		+ "WHERE b.title LIKE CONCAT('%', :title, '%')")
+	Page<BookTitleInfoResponse> findByTitleContaining(String title, Pageable pageable);
 }

--- a/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
+++ b/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
@@ -3,6 +3,8 @@ package com.example.OMEB.domain.book.presentation.controller;
 import com.example.OMEB.domain.book.api.BookInfoControllerApi;
 import com.example.OMEB.domain.book.application.usecase.BookUseCase;
 import com.example.OMEB.domain.book.presentation.dto.response.BookInfoResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookPageResponse;
+import com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.EmotionBookTitleInfoListResponse;
 import com.example.OMEB.domain.review.persistence.vo.TagName;
@@ -17,9 +19,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -59,6 +65,19 @@ public class BookInfoController implements BookInfoControllerApi {
     public ResponseEntity<ResponseBody<EmotionBookTitleInfoListResponse>> getEmotionRank(@RequestParam("emotion") @Schema(description = "감정", example = "ANGER") TagName emotion) {
         log.info("[BookInfoController] (getEmotionRank) get emotion rank request");
         return ResponseEntity.ok(createSuccessResponse(bookUseCase.getEmotionRank(emotion)));
+    }
+
+    @PreAuthorize("permitAll()")
+    @GetMapping("/v1/book/search")
+    public ResponseEntity<ResponseBody<BookPageResponse>> getBookSearch(@RequestParam("title") @Schema(description = "책 제목", example = "자바의 정석") String title,
+        @RequestParam(defaultValue = "1") @Schema(description = "조회할 페이지 넘버(가장 작은 수 1)", example = "1") @Size(min=1) int page,
+        @RequestParam(defaultValue = "10") @Schema(description = "한 페이지의 조회 될 책 수",example = "10") int size,
+        @RequestParam(defaultValue = "DESC") @Schema(description = "정렬 방법" , example = "DESC") String sortDirection,
+        @RequestParam(defaultValue = "createdAt") @Schema(description = "정렬 기준",example = "createdAt") String sortBy) {
+
+        Pageable pageable = PageRequest.of(page-1, size, Sort.Direction.fromString(sortDirection), sortBy);
+        log.info("[BookInfoController] (getBookSearch) get book search request");
+        return ResponseEntity.ok(createSuccessResponse(bookUseCase.getBookSearch(title,pageable)));
     }
 
 

--- a/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
+++ b/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
@@ -4,21 +4,14 @@ import com.example.OMEB.domain.book.api.BookInfoControllerApi;
 import com.example.OMEB.domain.book.application.usecase.BookUseCase;
 import com.example.OMEB.domain.book.presentation.dto.response.BookInfoResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookPageResponse;
-import com.example.OMEB.domain.book.presentation.dto.response.BookTitleInfoResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.BookTitleListResponse;
 import com.example.OMEB.domain.book.presentation.dto.response.EmotionBookTitleInfoListResponse;
 import com.example.OMEB.domain.review.persistence.vo.TagName;
-import com.example.OMEB.global.aop.AssignUserId;
 import com.example.OMEB.global.aop.UserPrincipal;
 import com.example.OMEB.global.base.dto.ResponseBody;
 import com.example.OMEB.global.jwt.CustomUserPrincipal;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static com.example.OMEB.global.base.dto.SuccessResponseBody.createSuccessResponse;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
+++ b/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
@@ -10,6 +10,7 @@ import com.example.OMEB.domain.review.persistence.vo.TagName;
 import com.example.OMEB.global.aop.UserPrincipal;
 import com.example.OMEB.global.base.dto.ResponseBody;
 import com.example.OMEB.global.jwt.CustomUserPrincipal;
+import com.example.OMEB.global.utils.StringBlankUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
@@ -69,7 +70,7 @@ public class BookInfoController implements BookInfoControllerApi {
 
         Pageable pageable = PageRequest.of(page-1, size, Sort.Direction.fromString(sortDirection), sortBy);
         log.info("[BookInfoController] (getBookSearch) get book search request");
-        return ResponseEntity.ok(createSuccessResponse(bookUseCase.getBookSearch(title,pageable)));
+        return ResponseEntity.ok(createSuccessResponse(bookUseCase.getBookSearch(StringBlankUtils.stringSideNotBlank(title),pageable)));
     }
 
 

--- a/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
+++ b/src/main/java/com/example/OMEB/domain/book/presentation/controller/BookInfoController.java
@@ -63,7 +63,7 @@ public class BookInfoController implements BookInfoControllerApi {
     @PreAuthorize("permitAll()")
     @GetMapping("/v1/book/search")
     public ResponseEntity<ResponseBody<BookPageResponse>> getBookSearch(@RequestParam("title") @Schema(description = "책 제목", example = "자바의 정석") String title,
-        @RequestParam(defaultValue = "1") @Schema(description = "조회할 페이지 넘버(가장 작은 수 1)", example = "1") @Size(min=1) int page,
+        @RequestParam(defaultValue = "1") @Schema(description = "조회할 페이지 넘버(가장 작은 수 1)", example = "1") int page,
         @RequestParam(defaultValue = "10") @Schema(description = "한 페이지의 조회 될 책 수",example = "10") int size,
         @RequestParam(defaultValue = "DESC") @Schema(description = "정렬 방법" , example = "DESC") String sortDirection,
         @RequestParam(defaultValue = "createdAt") @Schema(description = "정렬 기준",example = "createdAt") String sortBy) {

--- a/src/main/java/com/example/OMEB/domain/book/presentation/dto/response/BookPageResponse.java
+++ b/src/main/java/com/example/OMEB/domain/book/presentation/dto/response/BookPageResponse.java
@@ -1,0 +1,32 @@
+package com.example.OMEB.domain.book.presentation.dto.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import com.example.OMEB.domain.review.presentation.dto.response.ReviewInfoResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "책 페이지 응답")
+public class BookPageResponse {
+	@Schema(description = "페이지 오프셋", example = "1")
+	private int pageOffset;
+	@Schema(description = "페이지 사이즈", example = "10")
+	private int pageSize;
+	@Schema(description = "총 페이지 수", example = "10")
+	private int totalPage;
+	@Schema(description = "책 정보 리스트")
+	private List<BookTitleInfoResponse> bookTitleInfoResponseLists;
+
+	public BookPageResponse(Page<BookTitleInfoResponse> bookTitleInfoResponsePage) {
+		this.pageOffset = bookTitleInfoResponsePage.getNumber() + 1;
+		this.pageSize = bookTitleInfoResponsePage.getContent().size();
+		this.totalPage = bookTitleInfoResponsePage.getTotalPages();
+		this.bookTitleInfoResponseLists = bookTitleInfoResponsePage.getContent();
+	}
+}

--- a/src/main/java/com/example/OMEB/domain/review/persistence/vo/TagName.java
+++ b/src/main/java/com/example/OMEB/domain/review/persistence/vo/TagName.java
@@ -17,6 +17,7 @@ public enum TagName {
     ACCOMPLISHMENT,
     ;
 
+    // TODO : data binder 추후 추가하여 validation 진행 해야함
     @JsonCreator
     public static TagName fromString(String value) {
         for(TagName tagName : TagName.values()) {

--- a/src/main/java/com/example/OMEB/global/utils/StringBlankUtils.java
+++ b/src/main/java/com/example/OMEB/global/utils/StringBlankUtils.java
@@ -1,0 +1,23 @@
+package com.example.OMEB.global.utils;
+
+public class StringBlankUtils {
+
+	/**
+	 * 문자열 모든 공백을 제거한다.
+	 * @param str
+	 * @return 문자열이 제거된 문자열
+	 */
+	public static String stringAllNotBlank(String str) {
+		return str.replace(" ", "");
+	}
+
+	/**
+	 * 문자열의 양쪽 공백을 제거한다.
+	 * @param str
+	 * @return 양쪽 공백을 제거한 문자열
+	 */
+	public static String stringSideNotBlank(String str) {
+		return str.trim();
+	}
+
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- BookInfoController 에 책 검색 api 구현 
- swagger 적용
- string 공백 제거 util로 생성

### ❓ 리뷰 포인트

- 책 검색 controller -> usecase -> repo 순으로 봐주세요

### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
