### PR TITLE
유저 입력 텍스트 -> 태그 변환 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
@@ -68,6 +70,10 @@ dependencies {
 
 	//mongodb
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
+	// spring ai
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+	implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/OMEB/domain/ai/application/service/OpenAiService.java
+++ b/src/main/java/com/example/OMEB/domain/ai/application/service/OpenAiService.java
@@ -1,0 +1,59 @@
+package com.example.OMEB.domain.ai.application.service;
+
+import com.example.OMEB.domain.ai.presentation.dto.response.AiTagResponse;
+import com.example.OMEB.domain.review.persistence.vo.TagName;
+import com.example.OMEB.global.base.exception.ErrorCode;
+import com.example.OMEB.global.base.exception.ServiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Service;
+
+@Service
+@PropertySource("classpath:security/application-security.yml")
+public class OpenAiService {
+    @Value("${spring.ai.openai.api-key}")
+    private String apiKey;
+    @Value("${spring.ai.openai.chat.options.model}")
+    private String model;
+
+    public AiTagResponse chatToAi(String text){
+        StringBuilder sb = new StringBuilder();
+        sb.append("다음 텍스트의 감정을 분류하세요 ")
+                .append("설명하지 말고 무조건 하나의 단어로만 대답해야합니다. : ")
+                .append(text).append("\n")
+                .append("감정 : DEPRESSION, ANGER, ANXIETY, LONELINESS, JEALOUSY, HAPPINESS, " +
+                        "LETHARGY, LOVE, ACCOMPLISHMENT");
+        ChatResponse response = new OpenAiChatModel(new OpenAiApi(apiKey))
+                .call(new Prompt(sb.toString(),
+                        OpenAiChatOptions.builder()
+                                .withModel(model).build()));
+        String tag = response.getResult().getOutput().getContent().toUpperCase();
+        try {
+            TagName.valueOf(tag);
+        } catch (IllegalArgumentException e) {
+            sb.append("\n유효하지 않은 감정 태그입니다: ").append(tag)
+                    .append("\n제발 아무 설명도 하지 말고 위의 감정 중 하나의 단어로만 대답해");
+
+            response = new OpenAiChatModel(new OpenAiApi(apiKey))
+                    .call(new Prompt(sb.toString(),
+                            OpenAiChatOptions.builder()
+                                    .withModel(model).build()));
+            tag = response.getResult().getOutput().getContent().toUpperCase();
+            try {
+                TagName.valueOf(tag);
+            } catch (IllegalArgumentException ex) {
+                throw new ServiceException(ErrorCode.NOT_FOUND_TAG);
+            }
+        }
+        return new AiTagResponse(tag);
+    }
+}

--- a/src/main/java/com/example/OMEB/domain/ai/presentation/api/OpenAiControllerApi.java
+++ b/src/main/java/com/example/OMEB/domain/ai/presentation/api/OpenAiControllerApi.java
@@ -1,0 +1,26 @@
+package com.example.OMEB.domain.ai.presentation.api;
+
+import com.example.OMEB.domain.ai.presentation.dto.request.UserTextRequest;
+import com.example.OMEB.domain.ai.presentation.dto.response.AiTagResponse;
+import com.example.OMEB.global.base.dto.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "OpenAi Api", description = "텍스트 -> 태그 변환 API")
+public interface OpenAiControllerApi {
+    @Operation(summary = "태그 변환 API", description = "태그 변환 요청 API")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+                    content = {@Content(schema = @Schema(implementation = AiTagResponse.class),mediaType = "application/json")}),
+            @ApiResponse(responseCode = "TAG_0001", description = "태그 변환을 실패했습니다.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "COMMON_0001", description = "텍스트 입력 형식이 올바르지 않습니다.", content = @Content(mediaType = "application/json"))
+    })
+    public ResponseEntity<ResponseBody<AiTagResponse>> convertToTag(@RequestBody @Valid UserTextRequest userTextRequest);
+}

--- a/src/main/java/com/example/OMEB/domain/ai/presentation/controller/OpenAiController.java
+++ b/src/main/java/com/example/OMEB/domain/ai/presentation/controller/OpenAiController.java
@@ -1,0 +1,31 @@
+package com.example.OMEB.domain.ai.presentation.controller;
+
+import com.example.OMEB.domain.ai.application.service.OpenAiService;
+import com.example.OMEB.domain.ai.presentation.api.OpenAiControllerApi;
+import com.example.OMEB.domain.ai.presentation.dto.request.UserTextRequest;
+import com.example.OMEB.domain.ai.presentation.dto.response.AiTagResponse;
+import com.example.OMEB.global.base.dto.ResponseBody;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.OMEB.global.base.dto.SuccessResponseBody.createSuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/ai")
+public class OpenAiController implements OpenAiControllerApi {
+    private final OpenAiService openAiService;
+
+    @PostMapping()
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ResponseBody<AiTagResponse>> convertToTag(@RequestBody @Valid UserTextRequest userTextRequest){
+        return ResponseEntity.ok(createSuccessResponse(openAiService.chatToAi(userTextRequest.getText())));
+    }
+
+}

--- a/src/main/java/com/example/OMEB/domain/ai/presentation/dto/request/UserTextRequest.java
+++ b/src/main/java/com/example/OMEB/domain/ai/presentation/dto/request/UserTextRequest.java
@@ -1,0 +1,15 @@
+package com.example.OMEB.domain.ai.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(name = "UserTextRequest", description = "태그 변환 요청")
+public class UserTextRequest {
+    @NotEmpty(message = "텍스트가 비어서는 안됩니다.")
+    @Schema(description = "유저 입력 텍스트", example = "많이 짜증나고 화난다.")
+    private String text;
+}

--- a/src/main/java/com/example/OMEB/domain/ai/presentation/dto/response/AiTagResponse.java
+++ b/src/main/java/com/example/OMEB/domain/ai/presentation/dto/response/AiTagResponse.java
@@ -1,0 +1,15 @@
+package com.example.OMEB.domain.ai.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "AiTagResponse", description = "태그 변환 결과 응답")
+public class AiTagResponse {
+    @Schema(description = "태그", example = "ANXIETY")
+    private String tag;
+}


### PR DESCRIPTION
<!-- 제목은 `[#이슈번호] 제목` 으로 작성한다. ex) [#8] 결제 기능 -->

### 🌱 작업 사항 
- 입력 텍스트 enum 태그로 변환 로직 구현
### ❓ 리뷰 포인트
- 서비스 로직만 보면 될 것 같습니다.
- 처음에 올바른 출력을 받지 못하면 똑같은 문장에 명령을 덧붙여 재요청하고, 재요청도 실패시 오류를 반환하게 일단 만들었습니다.
- 무료가 없어져서 유료 Ai로 만들었습니다. 제일 싼 걸로 하긴 했는데 너무 남발하면 요금폭탄 우려,,
### 🦄 관련 이슈
resolves #이슈번호 <!-- pr이 머지되면 이슈가 자동으로 close되게 합니다. 만약 자동 close를 하지 않고 이슈만 링크한다면 resolves를 삭제한다.-->
